### PR TITLE
build config for bintray and removing the route to local jdk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,5 +35,6 @@ dependencies {
     compile 'com.android.support:appcompat-v7:25.3.0'
     compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha8'
     testCompile 'junit:junit:4.12'
-    compile project(path: ':lifxhttpandroidlibrary')
+    compile 'com.multimeleon.android.lifxhttpandroidlibrary:lifxhttpandroidlibrary:0.0.2'
+
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,10 +10,9 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-bintrayUser=user
-bintrayApiKey=keys
+bintrayUser=username
+bintrayApiKey=apikey

--- a/lifxhttpandroidlibrary/build.gradle
+++ b/lifxhttpandroidlibrary/build.gradle
@@ -8,7 +8,7 @@ task generateSourcesJar(type: Jar) {
 }
 
 group = 'com.multimeleon.android.lifxhttpandroidlibrary' // Change this to match your package name
-version = '0.0.1' // Change this to match your version number
+version = '0.0.2' // Change this to match your version number
 
 // Java8 not fully supported in library projects yet, https://code.google.com/p/android/issues/detail?id=211386
 // this is a temporary workaround to get at least lambdas compiling
@@ -70,15 +70,15 @@ bintray {
     key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
     configurations = ['archives']
     pkg {
-        repo = 'maven'
-        name = 'com.multimeleon.android.lifxhttpandroidlibrary'
+        repo = 'LifxHttpAndroid'
+        name = 'com.multimeleon.android'
         licenses = ['Apache-2.0']
         vcsUrl = 'https://github.com/pjwelcome/LifxHttpAndroid.git'
         websiteUrl = 'https://pjwelcome.github.io/LifxHttpAndroid'
         version {
-            name = '0.0.1'
+            name = '0.0.2'
             desc = 'Lifx lights library for Android'
-            vcsTag = '0.0.1'
+            vcsTag = '0.0.2'
             released = new Date()
         }
     }


### PR DESCRIPTION
Updated the version to 0.0.2
removed the routing to local JDK
renamed library for bintray